### PR TITLE
Feat: Provide TypeScript types 

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -149,7 +149,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: _framework
-          path: Bindings/JS/_framework
+          path: Bindings/JS/public/_framework
 
       - name: Run build
         working-directory: ./Bindings/JS

--- a/Bindings/JS/package.json
+++ b/Bindings/JS/package.json
@@ -11,7 +11,7 @@
     ".": {
       "import": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs"
+        "default": "./dist/index.js"
       },
       "require": {
         "types": "./dist/index.d.ts",

--- a/Bindings/JS/package.json
+++ b/Bindings/JS/package.json
@@ -2,14 +2,26 @@
   "name": "smoogipoo.osu-native",
   "version": "1.0.0",
   "type": "module",
-  "main": "./index.cjs",
-  "module": "./index.js",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "exports": {
-    "import": "./index.js",
-    "require": "./index.cjs"
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    }
   },
+  "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "npx rollup -i index.js -o index.cjs --format cjs --external ./_framework/dotnet.js",
+    "build": "vite build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -24,6 +36,9 @@
   "homepage": "https://github.com/smoogipoo/osu-native#readme",
   "description": "",
   "devDependencies": {
-    "rollup": "^4.18.0"
+    "typescript": "^5.5.4",
+    "vite": "^5.3.5",
+    "vite-plugin-cjs-interop": "^2.1.1",
+    "vite-plugin-dts": "4.0.0-beta.1"
   }
 }

--- a/Bindings/JS/package.json
+++ b/Bindings/JS/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "typescript": "^5.5.4",
     "vite": "^5.3.5",
-    "vite-plugin-cjs-interop": "^2.1.1",
     "vite-plugin-dts": "4.0.0-beta.1"
   }
 }

--- a/Bindings/JS/src/_framework/dotnet.d.ts
+++ b/Bindings/JS/src/_framework/dotnet.d.ts
@@ -1,0 +1,2 @@
+// Declaration for external module that will be placed in _framework folder
+export const dotnet: any;

--- a/Bindings/JS/src/index.ts
+++ b/Bindings/JS/src/index.ts
@@ -1,5 +1,9 @@
+interface Osu {
+    ComputeDifficulty(beatmapContent: string, rulesetId: number, mods: number): Promise<number>;
+}
+
 export default class Lazer {
-    static async create() {
+    static async create(): Promise<Lazer> {
         const { dotnet } = await import('./_framework/dotnet.js');
         const instance = new Lazer();
 
@@ -12,7 +16,9 @@ export default class Lazer {
         return instance;
     }
 
-    async computeDifficulty(beatmapContent, rulesetId, mods) {
+    async computeDifficulty(beatmapContent: string, rulesetId: number, mods: number): Promise<number> {
        return await this.osu.ComputeDifficulty(beatmapContent, Number(rulesetId), mods);
     }
+
+    private osu!: Osu;
 }

--- a/Bindings/JS/tsconfig.json
+++ b/Bindings/JS/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "target": "ESNext",
+    "lib": ["esnext"],
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "moduleResolution": "Bundler",
+    "outDir": "lib",
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "rootDir": "src",
+    "emitDeclarationOnly": true,
+    "strictPropertyInitialization": false
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib"
+  ]
+}

--- a/Bindings/JS/vite.config.ts
+++ b/Bindings/JS/vite.config.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
-import { cjsInterop } from "vite-plugin-cjs-interop";
 
 
 export default defineConfig({

--- a/Bindings/JS/vite.config.ts
+++ b/Bindings/JS/vite.config.ts
@@ -19,9 +19,6 @@ export default defineConfig({
     },
     rollupOptions: {
       external: ['./_framework/dotnet.js'],
-      output: {
-        interop: 'compat',
-      }
     }
   }
 })

--- a/Bindings/JS/vite.config.ts
+++ b/Bindings/JS/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vite'
+import dts from 'vite-plugin-dts'
+import { cjsInterop } from "vite-plugin-cjs-interop";
+
+
+export default defineConfig({
+  plugins: [
+    dts(),
+  ],
+  build: {
+    minify: false,
+    target: 'esnext',
+    
+    lib: {
+      entry: 'src/index.ts',
+      name: 'smoogipoo.osu-native',
+      fileName: 'index',
+      formats: ['es', 'cjs'],
+    },
+    rollupOptions: {
+      external: ['./_framework/dotnet.js'],
+      output: {
+        interop: 'compat',
+      }
+    }
+  }
+})


### PR DESCRIPTION
Closes #19 

Adds typescript definitions for the nodejs bindings.

List of changes:
- Moved entrypoint into `src` subdirectory to allow tsconfig to just include `src/**/*.ts`
- Using vite instead of rollup as a bundler (both rollup & tsup really did not want to stop transforming the dynamic import to require calls)
- Modified `exports`, `main`, `module` and `types` fields in package.json to point to the correct files (now in `/dist` subfolder)
- Added `files` property to `package.json` so npm only stores the files required to run the library
- Moved `Bindings/JS/_framework` directory to `Bindings/JS/public/_framework` directory. Vite will copy the contents of this directory as-is into the `dist` folder without trying to bundle it
- Updated path for `Bindings/JS/_framework` in github action

Optionally, a .gitignore file for the js folder would also be a good idea
```.gitignore
# Bindings/JS/.gitignore
node_modules/
dist/
public/_framework/
```