### PR TITLE
Fix: Add separate types for cjs builds

### DIFF
--- a/Bindings/JS/package.json
+++ b/Bindings/JS/package.json
@@ -14,12 +14,12 @@
         "default": "./dist/index.js"
       },
       "require": {
-        "types": "./dist/index.d.ts",
+        "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
     }
   },
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.cts",
   "scripts": {
     "build": "vite build",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/Bindings/JS/public/index.d.cts
+++ b/Bindings/JS/public/index.d.cts
@@ -1,4 +1,3 @@
 import { default as Lazer } from './index';
 
-
 export = Lazer

--- a/Bindings/JS/public/index.d.cts
+++ b/Bindings/JS/public/index.d.cts
@@ -1,0 +1,4 @@
+import { default as Lazer } from './index';
+
+
+export = Lazer


### PR DESCRIPTION
Seems like I messed up the commonjs types a little in #23 
The cjs build uses `module.exports = Lazer` and not `export default Lazer`, but only one d.ts file was generated for both which used the `export default` syntax.

Ran into an error on my own project (which is using cjs server-side) because of this
![image](https://github.com/user-attachments/assets/3012a1c9-d4bf-4aa8-98c2-49cffbd8c083)

See also: https://arethetypeswrong.github.io/?p=smoogipoo.osu-native%402024.727.1

It's a bit of a hack, but I couldn't get the typescript compiler to output actual cjs declarations, so I added a `index.d.cts` file to the public dir as a workaround, which declares the types with the correct exports syntax. As long as the library only has one default export this will work.

I'm not super familiar with cjs+typescript myself, but I ran the output against `are-the-types-wrong/cli` and it says the types are correct now.
![image](https://github.com/user-attachments/assets/fa4cdfb2-174f-4037-8c1c-cc41d02fdf96)

An alternative solution would be to completely drop cjs support, since tsc/most bundlers support interop for esm modules in commonjs projects, and commonjs isn't really that common anymore.

How to verify the types yourself:
Build & pack the bindings project, the run against `are-the-types-wrong/cli`
Instead of installing the package, the resulting tgz file can also be uploaded on https://arethetypeswrong.github.io/
```sh
npm build
npm pack
npm i -g @arethetypeswrong/cli
attw .\smoogipoo.osu-native-1.0.0.tgz
```